### PR TITLE
Filling config.md automatically

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,9 @@ version = "0.1.0"
 [deps]
 CommonMark = "a80b9123-70ca-4bc0-993e-6e3bcb318db6"
 Franklin = "713c75ef-9fc9-4b05-94a9-213340da978e"
+LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 NodeJS = "2bd173c7-0d6d-553b-b6af-13a54713934c"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
 CommonMark = "0.3"

--- a/src/PkgPage.jl
+++ b/src/PkgPage.jl
@@ -3,7 +3,7 @@ module PkgPage
 import Franklin
 import CommonMark
 import NodeJS
-using Pkg
+using Pkg: TOML
 using LibGit2: LibGit2, GitRemote, GitRepo
 
 export newpage

--- a/src/PkgPage.jl
+++ b/src/PkgPage.jl
@@ -3,6 +3,8 @@ module PkgPage
 import Franklin
 import CommonMark
 import NodeJS
+using Pkg
+using LibGit2: LibGit2, GitRemote, GitRepo
 
 export newpage
 export serve

--- a/src/instantiate.jl
+++ b/src/instantiate.jl
@@ -87,7 +87,7 @@ function fill(v::Val{:docs_url})
     try 
         git_remote = LibGit2.get(GitRemote, GitRepo(pwd()), "origin")
         url = LibGit2.url(git_remote)
-        m = match(r"github\.com/(?<user>.*?)/(?<repo>.*?)(\.git)", url)
+        m = match(r"github\.com\/(?<user>.*?)\/(?<repo>.*?)(\.git)", url)
         docs_url = "https://$(m[:user]).github.io/$(m[:repo])/stable/"
         return docs_url
     catch e 
@@ -99,7 +99,7 @@ function fill(v::Val{:github_repo})
     try 
         git_remote = LibGit2.get(GitRemote, GitRepo(pwd()), "origin")
         url = LibGit2.url(git_remote)
-        url = replace(url, r"https?://github\.com/" => "")
+        url = replace(url, r"https?://github\.com\/" => "")
         url = replace(url, r"\.git$" => "")
         return url
     catch 

--- a/src/web/config.md
+++ b/src/web/config.md
@@ -10,9 +10,9 @@ The latter allows you to plug in values that you would have defined here.
 -->
 
 <!-- META DEFINITIONS -->
-@def title        = "YourPackage.jl"
+@def title        = "{{ title }}"
 @def description  = "Short description of your package"
-@def authors      = "Grace Hopper, Rick Sanchez"
+@def authors      = "{{ authors }}"
 @def prepath      = "YourPackage.jl"
 @def favicon_path = "/assets/favicon.ico"
 
@@ -26,7 +26,7 @@ The latter allows you to plug in values that you would have defined here.
   - nav_logo_path: where the logo is
 -->
 @def add_docs  = true
-@def docs_url  = "https://franklinjl.org/"
+@def docs_url  = "{{ docs_url }}"
 @def docs_name = "Docs"
 
 @def add_nav_logo   = true
@@ -58,7 +58,7 @@ The latter allows you to plug in values that you would have defined here.
     """
 @def header_padding_top  = "55px" <!-- 55 = touching nav bar -->
 @def add_github_button   = true
-@def github_repo         = "tlienart/Franklin.jl"
+@def github_repo         = "{{ github_repo }}"
 
 <!-- COLOR PALETTE
 you can use Hex, RGB or SVG color names


### PR DESCRIPTION
Idea for #11 

Currently just parses `{{ [a-z_]+ }}` in the `config.md` with a regular expression.
If something fails it just copies the config as it is with `{{ }}` which is probably ugly and I think should never happen. If reading `Project.toml` or git fails then the same default is used as before.

For me it was just a try to try out `Val` in dispatch a bit more. Hopefully it is not too ugly.

