### PR TITLE
add view on github button

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgPage"
 uuid = "e7214860-93a8-4f22-b43d-bd447d1a2094"
 authors = ["Thibaut Lienart, Zlatan Vasović"]
-version = "0.1.2"
+version = "0.2.0"
 
 [deps]
 CommonMark = "a80b9123-70ca-4bc0-993e-6e3bcb318db6"

--- a/page/_layout/header.html
+++ b/page/_layout/header.html
@@ -6,7 +6,10 @@
   {{end}}
     <h1>{{title}}</h1>
     <div class="lead">{{description}}</div>
-    {{if add_github_button}}
+    {{if add_github_view}}
+      <a class="github-button" href="https://github.com/{{github_repo}}" data-size="large" aria-label="View {{title}} on GitHub">View on GitHub</a>
+    {{end}}
+    {{if add_github_star}}
       <a class="github-button" href="https://github.com/{{github_repo}}" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star {{title}} on GitHub">Star</a>
     {{end}}
   </div>

--- a/page/config.md
+++ b/page/config.md
@@ -61,12 +61,15 @@ The latter allows you to plug in values that you would have defined here.
                         don't pick a value between the two as the exact
                         look is browser dependent). When use_hero = true,
                         hero_margin_top is used instead.
+
   - use_hero:           if false, main bar stretches from left to right
                         otherwise boxed
   - hero_width:         width of the hero, for instance 80% will mean the
                         hero will stretch over 80% of the width of the page.
   - hero_margin_top     used instead of header_margin_top if use_hero is true
-  - add_github_button:  whether to add a "Star this package" button in header
+
+  - add_github_view:    whether to add a "View on GitHub" button in header
+  - add_github_star:    whether to add a "Star this package" button in header
   - github_repo:        path to the GitHub repo for the GitHub button
 -->
 @def use_header_img     = true
@@ -80,8 +83,9 @@ The latter allows you to plug in values that you would have defined here.
 @def hero_width         = "80%"
 @def hero_margin_top    = "100px"
 
-@def add_github_button  = true
-@def github_repo        = "tlienart/PkgPage.jl"
+@def add_github_view  = true
+@def add_github_star  = true
+@def github_repo      = "tlienart/PkgPage.jl"
 
 <!-- SECTION LAYOUT
 NOTE:


### PR DESCRIPTION
closes #17 

looks like

![Screenshot 2020-06-17 at 14 40 25](https://user-images.githubusercontent.com/10897531/84899095-80caf380-b0a8-11ea-9ebf-93a8b30d16f3.png)

minor release with it as it changes the name of the variables to 

```
add_github_view
add_github_star
```

(in the screenshot above, both are true)