### PR TITLE
Store `.gitattributes` within `path`

### DIFF
--- a/src/instantiate.jl
+++ b/src/instantiate.jl
@@ -45,7 +45,7 @@ function newpage(; path="page", overwrite=false)
     # Try placing the `.gitattributes`
     name = ".gitattributes"
     src = joinpath(store, name)
-    dst = name
+    dst = joinpath(path, name)
     cp(src, dst, force=overwrite)
     chmod(dst, 0o644)
 


### PR DESCRIPTION
I'm not certain if this is intended, but without this, we can't use `PkgPage.jl` in a repository that already has a `.gitattributes`.