### PR TITLE
Use NodeJS.jl for purge

### DIFF
--- a/src/instantiate.jl
+++ b/src/instantiate.jl
@@ -108,7 +108,7 @@ function optimize(; input="page", output="", purge=true, kw...)
         io = IOBuffer()
         run(pipeline(`$(NodeJS.npm_cmd()) root`, stdout=io))
         nodepath = String(take!(io))
-        run(`$(strip(nodepath))/purgecss/bin/purgecss.js --css __site/css/bootstrap.min.css --content __site/index.html --output __site/css/bootstrap.min.css`)
+        run(`$(NodeJS.nodejs_cmd()) $(strip(nodepath))/purgecss/bin/purgecss.js --css __site/css/bootstrap.min.css --content __site/index.html --output __site/css/bootstrap.min.css`)
     end
 
     # if required, copy the content of `__site` to a subfolder so that


### PR DESCRIPTION
This will use NodeJS.jl for the purge instead of the global installed node.
If node was not installed, this would have thrown an error previously:
```
/usr/bin/env: ‘node’: No such file or directory
ERROR: LoadError: failed process: Process(`/cache/build/default-deepsea1-0/julia-computing-1/darpa-triad/node_modules/purgecss/bin/purgecss.js --css __site/css/bootstrap.min.css --content __site/index.html --output __site/css/bootstrap.min.css`, ProcessExited(127)) [127]
```